### PR TITLE
Bumped package.json version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hucssley",
-  "version": "0.1.0",
+  "version": "1.0.0",
   "description": "",
   "keywords": [],
   "main": "src/_index.scss",


### PR DESCRIPTION
This version bump represents us bringing our hucssley into line with master from the original repository (as our version here is a fork from the original and hasnt been updated in several years).

Outside of the scope of this PR, I've already aligned our master with the latest master from the original repo.

This PR bumps our package.json up so we can publish a new version into GPM.